### PR TITLE
Chore: Fixed SWA start command and adjusted the local.settings.json config to be tabbed

### DIFF
--- a/dev-documentation/cipp-dev-guide/executing-local-development.md
+++ b/dev-documentation/cipp-dev-guide/executing-local-development.md
@@ -132,7 +132,7 @@ azurite
 cd X:\Development\CIPP-Project\CIPP-API
 func start
 cd X:\Development\CIPP-Project\CIPP
-yarn run start swa
+yarn run start-swa
 cd X:\Development\CIPP-Project\CIPP
 yarn run dev
 ```
@@ -140,6 +140,13 @@ yarn run dev
 If you need the APIs to connect to Microsoft 365 and / or to test the Secure Application Model functionality itself you have to make a `local.settings.json` file in the `CIPP-API` folder. This file isn't detected by git (because of the `.gitignore` file) so it's not pushed with any changes/contributions you make. This file stores the Secure Application Model tokens, and a Azure Storage connection string for the durable function queues.
 
 The contents of your `local.settings.json` file differs depending on whether you are using the Azurite storage emulator or Azure Storage itself.
+
+{% tabs %}
+{% tab title="Azurite (Local Emulator)" %}
+
+Use this configuration when running locally with the Azurite storage emulator.
+
+Wondering where the application secrets are? They are stored in the `DevSecrets` table.
 
 ```json
 {
@@ -169,6 +176,12 @@ The contents of your `local.settings.json` file differs depending on whether you
   }
 }
 ```
+
+{% endtab %}
+
+{% tab title="Azure Storage (Real Account)" %}
+
+Use this configuration when connecting directly to Azure Storage.
 
 ```json
 {
@@ -203,6 +216,9 @@ The contents of your `local.settings.json` file differs depending on whether you
   }
 }
 ```
+{% endtab %}
+{% endtabs %}
+
 
 Optional Values:
 


### PR DESCRIPTION
Corrected the command for starting the Static Web Application (SWA) and added tabbed views for the table storage using gitbooks format.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates developer docs to streamline local setup.
> 
> - Corrects SWA startup command to `yarn run start-swa`
> - Reorganizes `local.settings.json` guidance into tabbed sections for Azurite vs. Azure Storage, with brief explanations and a note that secrets live in `DevSecrets`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 33cfcf83bc1fe1082cb81b1142af48bc60d72cc3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->